### PR TITLE
copyright year warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 > Reusable banners for Node.js projects.
 
+Note: The script automates the copyright year.  Please edit the script if you do not want this behavour.
 
 ## Contributing
 Feel free to [submit a pull request](https://github.com/helpers/banners/issues) to add a banner.


### PR DESCRIPTION
Not sure how to handle this, since some may not want their (c) year changed on them, or if the script is ran on a local Grunt/Gulp toolchain, it may falsely update the year.

Perhaps remove the year automation all together?
