### PR TITLE
automate author, licenses.type

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 > Reusable banners for Node.js projects.
 
+## Usage
+
+The following fields in `package.json` are used:
+ * name
+ * description
+ * version
+ * homepage
+ * author:name
+ * licenses:type
+
+A copyright year is automatically updated.  If you want to keep a non-current year for the copyright notice, please hand-edit the file.
 
 ## Contributing
 Feel free to [submit a pull request](https://github.com/helpers/banners/issues) to add a banner.

--- a/index.js
+++ b/index.js
@@ -10,8 +10,8 @@ module.exports = {
     ' * <%= pkg.name %> v<%= pkg.version %>',
     ' * <%= pkg.homepage %>',
     '',
-    ' * Copyright (c) <%= grunt.template.date("yyyy") %>, Jon Schlinkert, Brian Woodward, contributors',
-    ' * Licensed under the MIT license.',
+    ' * Copyright (c) 2014 %>, <%= pkg.author.name %>, contributors',  //change year as needed
+    ' * Licensed under the <%= pkg.licenses.type %> license.',
     ' */\n\n'
   ].join('\n'),
 
@@ -19,7 +19,7 @@ module.exports = {
   min: [
     '/*! <%= pkg.name %> v<%= pkg.version %>',
     '<%= pkg.homepage %>',
-    '(c) <%= grunt.template.date("yyyy") %> Jon Schlinkert, Brian Woodward, contributors',
-    'MIT License */\n'
+    '(c) 2014 <%= pkg.author.name %>, contributors',  //change year as needed
+    '<%= pkg.licenses.type %> License */\n'
   ].join(' | ')
 };

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = {
     ' * <%= pkg.name %> v<%= pkg.version %>',
     ' * <%= pkg.homepage %>',
     '',
-    ' * Copyright (c) 2014 %>, <%= pkg.author.name %>, contributors',  //change year as needed
+    ' * Copyright (c) <%= grunt.template.date("yyyy") %>, <%= pkg.author.name %>, contributors',  //hardcode year as needed
     ' * Licensed under the <%= pkg.licenses.type %> license.',
     ' */\n\n'
   ].join('\n'),
@@ -19,7 +19,7 @@ module.exports = {
   min: [
     '/*! <%= pkg.name %> v<%= pkg.version %>',
     '<%= pkg.homepage %>',
-    '(c) 2014 <%= pkg.author.name %>, contributors',  //change year as needed
+    '(c) <%= grunt.template.date("yyyy") %>, <%= pkg.author.name %>, contributors',  //hardcode year as needed
     '<%= pkg.licenses.type %> License */\n'
   ].join(' | ')
 };


### PR DESCRIPTION
- Not sure how to insert all the authors, but poor Brian got left out of the [package.json](https://github.com/helpers/banners/blob/master/package.json) :(
- Not everyone uses MIT, but a few use multiple...
- Hard coded year & left comment per #1

? Not sure if `pkg.description` should be part of the big banner.

BTW, interesting use of `.join`.
